### PR TITLE
multiple sources at one bus and no other devices

### DIFF
--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -183,9 +183,8 @@ function _power_redistribution_ref(
             @warn "Only sources found at reference bus --- no redistribution of active or reactive power will take place"
             return
         else
-            error(
-                "Sources do not match P and/or Q requirements for reference bus. Total source P: $(Psources), Total source Q:$(Qsources) Bus P:$(P_gen), Bus Q:$(Q_gen)",
-            )
+            @warn "Total source P: $(Psources), Total source Q:$(Qsources) Bus P:$(P_gen), Bus Q:$(Q_gen)"
+            error("Sources do not match P and/or Q requirements for reference bus.")
         end
     end
     if length(devices_) == 1
@@ -285,9 +284,8 @@ function _reactive_power_redistribution_pv(sys::PSY.System, Q_gen::Float64, bus:
             @warn "Only sources found at PV bus --- no redistribution of reactive power will take place"
             return
         else
-            error(
-                "Sources do not match Q requirements for PV bus. Total source Q:$(Qsources), Bus Q:$(Q_gen)",
-            )
+            @warn "Total source Q:$(Qsources), Bus Q:$(Q_gen)"
+            error("Sources do not match Q requirements for PV bus.")
         end
     end
     if length(devices_) == 1

--- a/test/test_powerflow_with_sources.jl
+++ b/test/test_powerflow_with_sources.jl
@@ -1,0 +1,42 @@
+@testset "Powerflow with multiple sources at bus" begin
+    sys = System(100.0)
+    b = Bus(
+        number=1,
+        name="01",
+        bustype=BusTypes.REF,
+        angle=0.0,
+        magnitude=1.1,
+        voltage_limits=(0.0, 2.0),
+        base_voltage=230,
+    )
+    add_component!(sys, b)
+
+    #Test two sources with equal and opposite P and Q
+    s1 = Source(
+        name="source_1",
+        available=true,
+        bus=b,
+        active_power=0.5,
+        reactive_power=0.1,
+        R_th=1e-5,
+        X_th=1e-5,
+    )
+    add_component!(sys, s1)
+    s2 = Source(
+        name="source_2",
+        available=true,
+        bus=b,
+        active_power=-0.5,
+        reactive_power=-0.1,
+        R_th=1e-5,
+        X_th=1e-5,
+    )
+    add_component!(sys, s2)
+    @test run_powerflow!(sys, finite_diff=true)
+
+    #Create power mismatch, test for error 
+    set_active_power!(get_component(Source, sys, "source_1"), -0.4)
+    @test_throws ErrorException(
+        "Sources do not match P and/or Q requirements for reference bus.",
+    ) run_powerflow!(sys, finite_diff=true)
+end


### PR DESCRIPTION
This PR addresses another uncommon use case for re-distributing P/Q after running the power flow when there are multiple sources at a bus and no other devices. In this case, there is a check that the source set points match the power flow solution.

The behavior for all other scenarios should remain unchanged. 